### PR TITLE
"DOS line endings trip up charset #95"

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -2107,7 +2107,7 @@ int parsemail(char *mbox,	/* file name */
 			    if ('\"' == *cp)
 				cp++;	/* pass a quote too if one is there */
 
-			    sscanf(cp, "%128[^;\"\n]", charbuffer);
+			    sscanf(cp, "%128[^;\"\n\r]", charbuffer);
 			    /* save the charset info */
 			    charset = strsav(charbuffer);
 			}


### PR DESCRIPTION
Break off extraction of charset value after either newline or return, so we can coexist cleanly w. the DOS/Windows world.

(Mostly the code doesn't care that a stray line ending slips in, but then there's the principle of least astonishment...)