### PR TITLE
"base64 decode assumes input lines are in multiples of 4 #96"

### DIFF
--- a/src/base64.c
+++ b/src/base64.c
@@ -11,84 +11,134 @@
 ** - Encoded strings that ended with more than one = caused the decode 
 **   function+ to generate 3 extra zero bytes at the end of the output.
 */
-
-#include "hypermail.h"
+#include <stdlib.h>
+#include <strings.h>
 #include "base64.h"
 
-void base64Decode(char *intext, char *out, int *length)
+/*
+ * base64_alloc()
+ *	Allocate a new base64 decoder
+ */
+struct base64_state *
+base64_alloc(void)
 {
-    unsigned char ibuf[4];
-    unsigned char obuf[3];
-    char ignore;
-    char endtext = FALSE;
-    char ch;
-    int lindex = 0;
-    *length = 0;
+    struct base64_state *st = malloc(sizeof(struct base64_state));
+    if (!st) {
+	return(0);
+    }
+    bzero(st, sizeof(struct base64_state));
+    return(st);
+}
 
-    memset(ibuf, 0, sizeof(ibuf));
+/*
+ * base64_decode()
+ *
+ * Accept "intext", place resulting output in null-terminated "out".
+ *  "st" is our state, which will be updated and can carry state between
+ *  calls.
+ */
+int
+base64_decode(struct base64_state *st, const char *intext, char *out)
+{
+    char ignore, ch;
+    int length;
 
-    while (*intext) {
-	ch = *intext;
+    /* Ignore trailing garbage */
+    if (st->b_endtext) {
+	*out = '\0';
+	return(0);
+    }
 
-	ignore = FALSE;
-	if ((ch >= 'A') && (ch <= 'Z'))
+    length = 0;
+    while ((ch = *intext++)) {
+	ignore = 0;
+	if ((ch >= 'A') && (ch <= 'Z')) {
 	    ch = ch - 'A';
-	else if ((ch >= 'a') && (ch <= 'z'))
+	} else if ((ch >= 'a') && (ch <= 'z')) {
 	    ch = ch - 'a' + 26;
-	else if ((ch >= '0') && (ch <= '9'))
+	} else if ((ch >= '0') && (ch <= '9')) {
 	    ch = ch - '0' + 52;
-	else if (ch == '+')
+	} else if (ch == '+') {
 	    ch = 62;
-	else if (ch == '=') {	/* end of text */
-	    if (endtext)
+	} else if (ch == '=') {	/* end of text */
+	    if (st->b_endtext) {
 		break;
-	    endtext = TRUE;
-	    lindex--;
-	    if (lindex < 0)
-		lindex = 3;
-	}
-	else if (ch == '/')
+	    }
+	    st->b_endtext = 1;
+	    st->b_lindex--;
+	    if (st->b_lindex < 0) {
+		st->b_lindex = 3;
+	    }
+	} else if (ch == '/') {
 	    ch = 63;
-	else if (endtext)
+	} else if (st->b_endtext) {
 	    break;
-	else
-	    ignore = TRUE;
+	} else {
+	    ignore = 1;
+	}
 
 	if (!ignore) {
-	    if (!endtext) {
-		ibuf[lindex] = ch;
+	    if (!st->b_endtext) {
+		st->b_ibuf[st->b_lindex] = ch;
 
-		lindex++;
-		lindex &= 3;	/* use bit arithmetic instead of remainder */
+		st->b_lindex++;
+		st->b_lindex &= 3;	/* use bit arithmetic instead of remainder */
 	    }
-	    if ((0 == lindex) || endtext) {
+	    if ((0 == st->b_lindex) || st->b_endtext) {
 
-		obuf[0] = (ibuf[0] << 2) | ((ibuf[1] & 0x30) >> 4);
-		obuf[1] =
-		    ((ibuf[1] & 0x0F) << 4) | ((ibuf[2] & 0x3C) >> 2);
-		obuf[2] = ((ibuf[2] & 0x03) << 6) | (ibuf[3] & 0x3F);
+		st->b_obuf[0] = (st->b_ibuf[0] << 2) | ((st->b_ibuf[1] & 0x30) >> 4);
+		st->b_obuf[1] =
+		    ((st->b_ibuf[1] & 0x0F) << 4) | ((st->b_ibuf[2] & 0x3C) >> 2);
+		st->b_obuf[2] = ((st->b_ibuf[2] & 0x03) << 6) | (st->b_ibuf[3] & 0x3F);
 
-		switch (lindex) {
+		switch (st->b_lindex) {
 		case 1:
-		    sprintf(out, "%c", obuf[0]);
-		    out++;
-		    (*length)++;
+		    *out++ = st->b_obuf[0];
+		    length += 1;
 		    break;
 		case 2:
-		    sprintf(out, "%c%c", obuf[0], obuf[1]);
-		    out += 2;
-		    (*length) += 2;
+		    *out++ = st->b_obuf[0];
+		    *out++ = st->b_obuf[1];
+		    length += 2;
 		    break;
 		default:
-		    sprintf(out, "%c%c%c", obuf[0], obuf[1], obuf[2]);
-		    out += 3;
-		    (*length) += 3;
+		    *out++ = st->b_obuf[0];
+		    *out++ = st->b_obuf[1];
+		    *out++ = st->b_obuf[2];
+		    length += 3;
 		    break;
 		}
-		memset(ibuf, 0, sizeof(ibuf));
+		bzero(st->b_ibuf, sizeof(st->b_ibuf));
 	    }
 	}
-	intext++;
     }
     *out = 0;
+    return(length);
+}
+
+/*
+ * base64_free()
+ *	Release storage
+ */
+void
+base64_free(struct base64_state *st)
+{
+    free(st);
+}
+
+/*
+ * base64Decode()
+ *	Convenience wrapper when decoding a single line
+ */
+void
+base64Decode(const char *intext, char *out, int *length)
+{
+    struct base64_state *st = base64_alloc();
+
+    if (!st) {
+	*length = 0;
+	return;
+    }
+    *length = base64_decode(st, intext, out);
+    base64_free(st);
 }

--- a/src/base64.h
+++ b/src/base64.h
@@ -1,5 +1,28 @@
 /* 
 ** MIME Decode - base64.c
 */
+#ifndef BASE64_H
+#define BASE64_H
 
-void base64Decode(char *, char *, int *);
+/* Common state as you feed successive lines into base64_decode() */
+struct base64_state {
+    unsigned char b_ibuf[4];
+    unsigned char b_obuf[3];
+    char b_endtext;
+    int b_lindex;
+};
+
+/* Get a new one */
+extern struct base64_state *base64_alloc(void);
+
+/* Decode some base64, return count of chars placed in "out" */
+extern int base64_decode(struct base64_state *st,
+    const char *intext, char *out);
+
+/* All done */
+extern void base64_free(struct base64_state *);
+
+/* When you're bursting a single line */
+extern void base64Decode(const char *intext, char *out, int *length);
+
+#endif /* BASE64_H */


### PR DESCRIPTION
Convert base64 implementation of stateless to stateful, so you can feed in successive lines and get back the original binary.  The previous stateless implementation assumes that the input has no residual after processing a single line, which is not a semantic guaranteed by the base64-in-email standards (and, in fact, was found while processing exports from Tutanota).